### PR TITLE
Fix config typo

### DIFF
--- a/setting.conf.example
+++ b/setting.conf.example
@@ -9,7 +9,7 @@ log_level = "info"  # one of: debug, info, warning, error
 # Public Key Pair Configuration
 [[keypairs]]
 key1 = "<peer A public key>"
-key2 = "<peer B public key"
+key2 = "<peer B public key>"
 
 # Additional Public Key Pair Configuration
 # [[keypairs]]


### PR DESCRIPTION
## Summary
- close missing quote in `setting.conf.example`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fc454897c8322b10502f15120ec11